### PR TITLE
Fixes and improvements for running Qwen-Image-Edit on **trn2.3xlarge** (LNC=2, TP=4, CP=1)

### DIFF
--- a/torch-neuronx/inference/hf_pretrained_qwen_image_edit/README.md
+++ b/torch-neuronx/inference/hf_pretrained_qwen_image_edit/README.md
@@ -607,6 +607,85 @@ The `--enable-ccop-compute-overlap` flag is particularly important for tensor pa
 
 The transformer is the main bottleneck, accounting for ~80% of total inference time. V3 Language Model on Neuron is ~2-8x faster than CPU. V3 Vision Encoder on Neuron is ~10-15x faster than CPU (first call).
 
+## trn2.3xlarge Support
+
+The code works on trn2.3xlarge with the following configuration changes. This enables running on a much smaller (and cheaper) instance.
+
+### Configuration: LNC=2, TP=4, CP=1
+
+trn2.3xlarge has 2 NeuronCores. At the default LNC=2, this gives **4 logical cores** with 24 GB HBM each.
+
+| Setting | trn2.48xlarge | trn2.3xlarge |
+|---------|--------------|--------------|
+| LNC | 1 (8 logical cores) | 2 (4 logical cores, default) |
+| TP | 4 | 4 |
+| CP / DP | 2 | **1 (disabled)** |
+| World size | 8 | **4** |
+| NEURON_RT_NUM_CORES | 8 | **4** |
+| All on Neuron? | Yes | Yes |
+
+**Key**: Pass `--world_size 4` to `compile_transformer_v3_cp.py`. The script auto-derives `cp_degree = world_size // tp_degree = 1`, effectively disabling Context Parallel.
+
+### Compilation on trn2.3xlarge
+
+```bash
+# Compile transformer (CP disabled, world_size=4)
+python neuron_qwen_image_edit/compile_transformer_v3_cp.py \
+    --world_size 4 --height 1024 --width 1024
+
+# Compile language model (world_size=4)
+python neuron_qwen_image_edit/compile_language_model_v3.py \
+    --world_size 4
+
+# Compile vision encoder (use --load_bf16 to avoid OOM on 64GB RAM)
+python neuron_qwen_image_edit/compile_vision_encoder_v3.py \
+    --load_bf16
+
+# Compile VAE (unchanged)
+python neuron_qwen_image_edit/compile_vae.py
+```
+
+### Inference on trn2.3xlarge
+
+```bash
+NEURON_RT_NUM_CORES=4 python run_qwen_image_edit.py \
+    --use_v3_cp --use_v3_language_model --use_v3_vision_encoder \
+    --images input.jpg --prompt "convert to oil painting" \
+    --num_inference_steps 28
+```
+
+### Known Issues on trn2.3xlarge
+
+1. **VAE decoder compiler error at LNC=2**: `NEURON_CUSTOM_SILU=1` and `NEURON_FUSE_SOFTMAX=1` cause an internal compiler error (NCC_IBIR182) for the VAE decoder. The fix (included in this code) automatically disables these flags for decoder compilation.
+
+2. **Vision encoder OOM**: Loading the full pipeline in fp32 (~95 GB) exceeds the 64 GB system RAM on trn2.3xlarge. Use `--load_bf16` to load in bf16 and auto-convert to fp32 for compilation.
+
+3. **Multi-image sequence length overflow**: With 3 input images, the text encoder produces ~1042 tokens, exceeding the default `max_sequence_length=1024`. Recompile the language model with `--max_sequence_length 2048` and pass `--max_sequence_length 2048` to the run script.
+
+### Performance: trn2.3xlarge vs GPU
+
+Benchmarked on trn2.3xlarge (LNC=2, TP=4, CP=1) with SDK 2.28, spot pricing $0.90/hr:
+
+| Test | trn2.3xlarge | GPU (g6e.12xlarge, 4x L40S) | Ratio |
+|------|-------------|------------------------------|-------|
+| 1 img, 1024x1024, 28 steps | 83.1s (2.97 s/step) | 67.6s (2.41 s/step) | Neuron 1.23x slower |
+| 3 img, 768x1280, 28 steps | 92.9s (3.32 s/step) | 160.1s (5.72 s/step) | **Neuron 1.72x faster** |
+
+**Cost comparison** (28 steps, spot pricing):
+
+| Instance | $/hr | $/image (1 img, 1024x1024) |
+|----------|------|---------------------------|
+| trn2.3xlarge (spot) | $0.90 | **$0.021** |
+| g6e.12xlarge (spot, 4x L40S) | $4.94 | $0.093 |
+
+**Key finding**: Neuron is **4.4x cheaper per image** than GPU. For multi-image workloads, Neuron is both faster AND cheaper — NKI Flash Attention handles longer sequences far more efficiently than GPU attention (GPU slows 2.37x for 23% more tokens while Neuron slows only 12%).
+
+## Qwen-Image-Edit-2511 Compatibility
+
+The code was developed for `Qwen-Image-Edit-2509`. It is fully compatible with `Qwen-Image-Edit-2511` — the architectures are identical (same pipeline, transformer, VAE, encoder configs). 2511 is a weight-only update that adds one config field (`zero_cond_t: true`), handled by the diffusers pipeline.
+
+To use 2511, simply change the MODEL_ID or pass `--model_path Qwen/Qwen-Image-Edit-2511` to compile and run scripts. All components need recompilation with the new weights.
+
 ## Known Limitations
 
 1. **Fixed dimensions**: Models are compiled for specific dimensions. Different sizes require recompilation.

--- a/torch-neuronx/inference/hf_pretrained_qwen_image_edit/neuron_qwen_image_edit/compile_vae.py
+++ b/torch-neuronx/inference/hf_pretrained_qwen_image_edit/neuron_qwen_image_edit/compile_vae.py
@@ -1,4 +1,5 @@
 import os
+
 os.environ["NEURON_FUSE_SOFTMAX"] = "1"
 os.environ["NEURON_CUSTOM_SILU"] = "1"
 os.environ["XLA_DISABLE_FUNCTIONALIZATION"] = "0"
@@ -29,6 +30,7 @@ MODEL_ID = "Qwen/Qwen-Image-Edit-2509"
 
 class VAEEncoderWrapper(nn.Module):
     """Wrapper for VAE encoder."""
+
     def __init__(self, encoder):
         super().__init__()
         self.encoder = encoder
@@ -39,6 +41,7 @@ class VAEEncoderWrapper(nn.Module):
 
 class VAEDecoderWrapper(nn.Module):
     """Wrapper for VAE decoder."""
+
     def __init__(self, decoder):
         super().__init__()
         self.decoder = decoder
@@ -90,7 +93,7 @@ def compile_vae(args):
         attn_scales=original_vae_config.attn_scales,
         temperal_downsample=original_vae_config.temperal_downsample,
         dropout=original_vae_config.dropout,
-        input_channels=getattr(original_vae_config, 'input_channels', 3),
+        input_channels=getattr(original_vae_config, "input_channels", 3),
         latents_mean=original_vae_config.latents_mean,
         latents_std=original_vae_config.latents_std,
     )
@@ -103,7 +106,9 @@ def compile_vae(args):
 
     # Compile VAE Encoder
     print("Compiling VAE encoder...")
-    print(f"  Input shape: ({batch_size}, 3, {temporal_frames}, {args.height}, {args.width})")
+    print(
+        f"  Input shape: ({batch_size}, 3, {temporal_frames}, {args.height}, {args.width})"
+    )
     encoder = pipe.vae.encoder
     encoder.eval()
     upcast_norms_to_f32(encoder)
@@ -111,13 +116,15 @@ def compile_vae(args):
     with torch.no_grad():
         # Encoder input: (batch, channels, temporal_frames, height, width) - 5D for Conv3d
         encoder_input = torch.rand(
-            (batch_size, 3, temporal_frames, args.height, args.width), dtype=dtype)
+            (batch_size, 3, temporal_frames, args.height, args.width), dtype=dtype
+        )
         compiled_encoder = torch_neuronx.trace(
             encoder,
             encoder_input,
             compiler_workdir=f"{compiler_workdir}/vae_encoder",
             compiler_args=compiler_flags,
-            inline_weights_to_neff=False)
+            inline_weights_to_neff=False,
+        )
 
         encoder_dir = f"{compiled_models_dir}/vae_encoder"
         if not os.path.exists(encoder_dir):
@@ -126,8 +133,22 @@ def compile_vae(args):
         print(f"VAE encoder compiled and saved to {encoder_dir}")
 
     # Compile VAE Decoder
+    # NOTE: At LNC=2 (trn2.3xlarge default), NEURON_CUSTOM_SILU=1 and
+    # NEURON_FUSE_SOFTMAX=1 cause an internal compiler error (NCC_IBIR182)
+    # for the VAE decoder. The encoder compiles fine with these flags.
+    # We disable them for decoder compilation and restore afterward.
+    saved_silu = os.environ.get("NEURON_CUSTOM_SILU")
+    saved_softmax = os.environ.get("NEURON_FUSE_SOFTMAX")
+    os.environ["NEURON_CUSTOM_SILU"] = "0"
+    os.environ["NEURON_FUSE_SOFTMAX"] = "0"
+
     print("Compiling VAE decoder...")
-    print(f"  Input shape: ({batch_size}, {z_dim}, {latent_temporal}, {latent_height}, {latent_width})")
+    print(
+        f"  Input shape: ({batch_size}, {z_dim}, {latent_temporal}, {latent_height}, {latent_width})"
+    )
+    print(
+        f"  NOTE: NEURON_CUSTOM_SILU and NEURON_FUSE_SOFTMAX disabled for decoder (LNC=2 compatibility)"
+    )
     decoder = pipe.vae.decoder
     decoder.eval()
     upcast_norms_to_f32(decoder)
@@ -135,13 +156,16 @@ def compile_vae(args):
     with torch.no_grad():
         # Decoder input: (batch, z_dim, temporal_frames, latent_height, latent_width) - 5D
         decoder_input = torch.rand(
-            (batch_size, z_dim, latent_temporal, latent_height, latent_width), dtype=dtype)
+            (batch_size, z_dim, latent_temporal, latent_height, latent_width),
+            dtype=dtype,
+        )
         compiled_decoder = torch_neuronx.trace(
             decoder,
             decoder_input,
             compiler_workdir=f"{compiler_workdir}/vae_decoder",
             compiler_args=compiler_flags,
-            inline_weights_to_neff=False)
+            inline_weights_to_neff=False,
+        )
 
         decoder_dir = f"{compiled_models_dir}/vae_decoder"
         if not os.path.exists(decoder_dir):
@@ -149,35 +173,47 @@ def compile_vae(args):
         torch.jit.save(compiled_decoder, f"{decoder_dir}/model.pt")
         print(f"VAE decoder compiled and saved to {decoder_dir}")
 
+    # Restore NEURON_CUSTOM_SILU and NEURON_FUSE_SOFTMAX after decoder compilation
+    if saved_silu is not None:
+        os.environ["NEURON_CUSTOM_SILU"] = saved_silu
+    if saved_softmax is not None:
+        os.environ["NEURON_FUSE_SOFTMAX"] = saved_softmax
+
     # Compile quant_conv and post_quant_conv if they exist
-    if hasattr(pipe.vae, 'quant_conv') and pipe.vae.quant_conv is not None:
+    if hasattr(pipe.vae, "quant_conv") and pipe.vae.quant_conv is not None:
         print("Compiling quant_conv...")
         with torch.no_grad():
             quant_input = torch.rand(
-                (batch_size, z_dim * 2, latent_temporal, latent_height, latent_width), dtype=dtype)
+                (batch_size, z_dim * 2, latent_temporal, latent_height, latent_width),
+                dtype=dtype,
+            )
             compiled_quant = torch_neuronx.trace(
                 pipe.vae.quant_conv,
                 quant_input,
                 compiler_workdir=f"{compiler_workdir}/quant_conv",
                 compiler_args=compiler_flags,
-                inline_weights_to_neff=False)
+                inline_weights_to_neff=False,
+            )
             quant_dir = f"{compiled_models_dir}/quant_conv"
             if not os.path.exists(quant_dir):
                 os.makedirs(quant_dir)
             torch.jit.save(compiled_quant, f"{quant_dir}/model.pt")
             print(f"quant_conv compiled and saved to {quant_dir}")
 
-    if hasattr(pipe.vae, 'post_quant_conv') and pipe.vae.post_quant_conv is not None:
+    if hasattr(pipe.vae, "post_quant_conv") and pipe.vae.post_quant_conv is not None:
         print("Compiling post_quant_conv...")
         with torch.no_grad():
             post_quant_input = torch.rand(
-                (batch_size, z_dim, latent_temporal, latent_height, latent_width), dtype=dtype)
+                (batch_size, z_dim, latent_temporal, latent_height, latent_width),
+                dtype=dtype,
+            )
             compiled_post_quant = torch_neuronx.trace(
                 pipe.vae.post_quant_conv,
                 post_quant_input,
                 compiler_workdir=f"{compiler_workdir}/post_quant_conv",
                 compiler_args=compiler_flags,
-                inline_weights_to_neff=False)
+                inline_weights_to_neff=False,
+            )
             post_quant_dir = f"{compiled_models_dir}/post_quant_conv"
             if not os.path.exists(post_quant_dir):
                 os.makedirs(post_quant_dir)
@@ -186,6 +222,7 @@ def compile_vae(args):
 
     # Save VAE config
     import json
+
     vae_config = {
         "height": args.height,
         "width": args.width,
@@ -203,20 +240,45 @@ def compile_vae(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model_path", type=str, default=None,
-                        help="Path to model (local dir or HuggingFace ID). If not set, uses MODEL_ID with CACHE_DIR")
-    parser.add_argument("--height", type=int, default=512,
-                        help="Height of generated image (compile tile size)")
-    parser.add_argument("--width", type=int, default=512,
-                        help="Width of generated image (compile tile size)")
-    parser.add_argument("--temporal_frames", type=int, default=1,
-                        help="Number of temporal frames (1 for single image)")
-    parser.add_argument("--batch_size", type=int, default=1,
-                        help="Batch size for VAE (default: 1)")
-    parser.add_argument("--compiler_workdir", type=str, default="compiler_workdir",
-                        help="Directory for compiler artifacts")
-    parser.add_argument("--compiled_models_dir", type=str, default="compiled_models",
-                        help="Directory for compiled models")
+    parser.add_argument(
+        "--model_path",
+        type=str,
+        default=None,
+        help="Path to model (local dir or HuggingFace ID). If not set, uses MODEL_ID with CACHE_DIR",
+    )
+    parser.add_argument(
+        "--height",
+        type=int,
+        default=512,
+        help="Height of generated image (compile tile size)",
+    )
+    parser.add_argument(
+        "--width",
+        type=int,
+        default=512,
+        help="Width of generated image (compile tile size)",
+    )
+    parser.add_argument(
+        "--temporal_frames",
+        type=int,
+        default=1,
+        help="Number of temporal frames (1 for single image)",
+    )
+    parser.add_argument(
+        "--batch_size", type=int, default=1, help="Batch size for VAE (default: 1)"
+    )
+    parser.add_argument(
+        "--compiler_workdir",
+        type=str,
+        default="compiler_workdir",
+        help="Directory for compiler artifacts",
+    )
+    parser.add_argument(
+        "--compiled_models_dir",
+        type=str,
+        default="compiled_models",
+        help="Directory for compiled models",
+    )
     args = parser.parse_args()
 
     # Override MODEL_ID and CACHE_DIR if model_path is provided

--- a/torch-neuronx/inference/hf_pretrained_qwen_image_edit/neuron_qwen_image_edit/compile_vision_encoder_v3.py
+++ b/torch-neuronx/inference/hf_pretrained_qwen_image_edit/neuron_qwen_image_edit/compile_vision_encoder_v3.py
@@ -57,6 +57,7 @@ def load_pipeline(dtype=torch.float32):
 
 class f32Wrapper(nn.Module):
     """Wrapper to run normalization layers in float32 for numerical stability."""
+
     def __init__(self, original):
         super().__init__()
         self.original = original
@@ -73,7 +74,7 @@ def upcast_norms_to_f32(module):
     for name, child in module.named_children():
         if isinstance(child, (torch.nn.LayerNorm,)):
             setattr(module, name, f32Wrapper(child.to(torch.float32)))
-        elif 'RMSNorm' in child.__class__.__name__:
+        elif "RMSNorm" in child.__class__.__name__:
             setattr(module, name, f32Wrapper(child.to(torch.float32)))
         else:
             upcast_norms_to_f32(child)
@@ -128,7 +129,8 @@ def shard_vision_attention_fp32(tp_degree: int, attn):
         orig_qkv.out_features,
         bias=(orig_qkv.bias is not None),
         gather_output=False,
-        dtype=torch.float32)
+        dtype=torch.float32,
+    )
     attn.qkv.weight.data = get_sharded_data(orig_qkv.weight.data, 0)
     if orig_qkv.bias is not None:
         attn.qkv.bias.data = get_sharded_data(orig_qkv.bias.data, 0)
@@ -140,7 +142,8 @@ def shard_vision_attention_fp32(tp_degree: int, attn):
         orig_proj.out_features,
         bias=(orig_proj.bias is not None),
         input_is_parallel=True,
-        dtype=torch.float32)
+        dtype=torch.float32,
+    )
     attn.proj.weight.data = get_sharded_data(orig_proj.weight.data, 1)
     if orig_proj.bias is not None:
         attn.proj.bias.data = orig_proj.bias.data.detach()
@@ -173,7 +176,8 @@ def shard_vision_mlp_fp32(mlp):
         orig_gate.out_features,
         bias=(orig_gate.bias is not None),
         gather_output=False,
-        dtype=torch.float32)
+        dtype=torch.float32,
+    )
     mlp.gate_proj.weight.data = get_sharded_data(orig_gate.weight.data, 0)
     if orig_gate.bias is not None:
         mlp.gate_proj.bias.data = get_sharded_data(orig_gate.bias.data, 0)
@@ -185,7 +189,8 @@ def shard_vision_mlp_fp32(mlp):
         orig_up.out_features,
         bias=(orig_up.bias is not None),
         gather_output=False,
-        dtype=torch.float32)
+        dtype=torch.float32,
+    )
     mlp.up_proj.weight.data = get_sharded_data(orig_up.weight.data, 0)
     if orig_up.bias is not None:
         mlp.up_proj.bias.data = get_sharded_data(orig_up.bias.data, 0)
@@ -197,7 +202,8 @@ def shard_vision_mlp_fp32(mlp):
         orig_down.out_features,
         bias=(orig_down.bias is not None),
         input_is_parallel=True,
-        dtype=torch.float32)
+        dtype=torch.float32,
+    )
     mlp.down_proj.weight.data = get_sharded_data(orig_down.weight.data, 1)
     if orig_down.bias is not None:
         mlp.down_proj.bias.data = orig_down.bias.data.detach()
@@ -238,9 +244,9 @@ class NeuronVisionEncoderV3(nn.Module):
 
         # Shard the transformer blocks
         for i, block in enumerate(self.visual.blocks):
-            if hasattr(block, 'attn'):
+            if hasattr(block, "attn"):
                 block.attn = shard_vision_attention_fp32(tp_degree, block.attn)
-            if hasattr(block, 'mlp'):
+            if hasattr(block, "mlp"):
                 block.mlp = shard_vision_mlp_fp32(block.mlp)
             if i == 0:
                 print(f"  Sharded block 0 attention and MLP")
@@ -296,14 +302,16 @@ def compile_vision_encoder_v3(args):
     if image_size % patch_size != 0:
         raise ValueError(
             f"image_size ({image_size}) must be divisible by patch_size ({patch_size}). "
-            f"Valid sizes: 224, 336, 448, 560, etc.")
+            f"Valid sizes: 224, 336, 448, 560, etc."
+        )
 
     num_patches_per_side = image_size // patch_size
     if num_patches_per_side % spatial_merge_size != 0:
         raise ValueError(
             f"image_size / patch_size ({num_patches_per_side}) must be divisible by "
             f"spatial_merge_size ({spatial_merge_size}). "
-            f"Valid image sizes: 224, 336, 448, 560, etc.")
+            f"Valid image sizes: 224, 336, 448, 560, etc."
+        )
 
     num_patches_h = image_size // patch_size
     num_patches_w = image_size // patch_size
@@ -339,25 +347,38 @@ def compile_vision_encoder_v3(args):
 
     # Use NxDParallelState context for compilation
     with NxDParallelState(world_size=world_size, tensor_model_parallel_size=tp_degree):
-        print("Loading model...")
-        pipe = load_pipeline(torch.float32)
+        # On trn2.3xlarge (or instances with <96GB RAM), loading the full pipeline
+        # in fp32 (~95 GB) will OOM. Load in bf16 to save memory, then extract
+        # the vision encoder and explicitly convert its weights to fp32.
+        # On trn2.48xlarge, fp32 loading works fine.
+        load_dtype = torch.bfloat16 if args.load_bf16 else torch.float32
+        print(f"Loading model in {load_dtype}...")
+        pipe = load_pipeline(load_dtype)
 
         # Extract vision encoder
         original_visual = pipe.text_encoder.model.visual
 
-        # Save unsharded state dict before modifications
+        # Save unsharded state dict before modifications.
+        # CRITICAL: If pipeline was loaded in bf16, the state dict will be bf16.
+        # Vision encoder requires fp32 for accuracy, so we must explicitly cast.
         print("Saving unsharded state dict...")
-        unsharded_state = original_visual.state_dict()
+        unsharded_state = {
+            k: v.to(torch.float32) for k, v in original_visual.state_dict().items()
+        }
+
+        # Convert vision encoder to fp32 before sharding
+        if load_dtype != torch.float32:
+            original_visual = original_visual.to(torch.float32)
 
         # Create Neuron vision encoder with sharding
-        print(f"\nCreating Neuron vision encoder (sharding layers with TP={tp_degree})...")
-        neuron_vision_encoder = NeuronVisionEncoderV3(
-            original_visual, tp_degree
+        print(
+            f"\nCreating Neuron vision encoder (sharding layers with TP={tp_degree})..."
         )
+        neuron_vision_encoder = NeuronVisionEncoderV3(original_visual, tp_degree)
         neuron_vision_encoder = neuron_vision_encoder.to(torch.float32)
         neuron_vision_encoder.eval()
 
-        # Clear pipeline to save memory
+        # Clear pipeline to save memory (important on trn2.3xlarge)
         del pipe
         gc.collect()
 
@@ -423,13 +444,15 @@ def compile_vision_encoder_v3(args):
         # Collect inv_freq buffers from original model (they are not in state_dict)
         inv_freq_buffers = {}
         for name, buf in neuron_vision_encoder.visual.named_buffers():
-            if 'inv_freq' in name:
+            if "inv_freq" in name:
                 full_key = f"vision_encoder.visual.{name}"
                 inv_freq_buffers[full_key] = buf.to(torch.float32).clone()
         print(f"  Collected {len(inv_freq_buffers)} inv_freq buffers")
 
         for rank in range(tp_degree):
-            shard_file = os.path.join(weights_path, f"tp{rank}_sharded_checkpoint.safetensors")
+            shard_file = os.path.join(
+                weights_path, f"tp{rank}_sharded_checkpoint.safetensors"
+            )
             if not os.path.exists(shard_file):
                 print(f"  WARNING: {shard_file} not found!")
                 continue
@@ -440,7 +463,7 @@ def compile_vision_encoder_v3(args):
             original_size = sum(v.numel() * v.element_size() for v in data.values())
 
             # Remove master_weight tensors (they duplicate the sharded weights)
-            cleaned = {k: v for k, v in data.items() if 'master_weight' not in k}
+            cleaned = {k: v for k, v in data.items() if "master_weight" not in k}
 
             # Add inv_freq buffers
             cleaned.update(inv_freq_buffers)
@@ -449,8 +472,10 @@ def compile_vision_encoder_v3(args):
 
             # Save optimized checkpoint
             save_file(cleaned, shard_file)
-            print(f"  tp{rank}: {original_count} -> {len(cleaned)} tensors, "
-                  f"{original_size/1e9:.2f}GB -> {cleaned_size/1e9:.2f}GB")
+            print(
+                f"  tp{rank}: {original_count} -> {len(cleaned)} tensors, "
+                f"{original_size / 1e9:.2f}GB -> {cleaned_size / 1e9:.2f}GB"
+            )
 
         # Save config
         config = {
@@ -465,7 +490,7 @@ def compile_vision_encoder_v3(args):
             "dtype": "float32",
         }
         config_path = os.path.join(output_path, "config.json")
-        with open(config_path, 'w') as f:
+        with open(config_path, "w") as f:
             json.dump(config, f, indent=2)
 
         print(f"\nVision Encoder V3 compiled successfully!")
@@ -480,16 +505,37 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Compile Vision Encoder V3 using ModelBuilder API"
     )
-    parser.add_argument("--image_size", type=int, default=448,
-                        help="Vision encoder input image size (default: 448)")
-    parser.add_argument("--compiled_models_dir", type=str,
-                        default="/opt/dlami/nvme/compiled_models",
-                        help="Output directory for compiled models")
-    parser.add_argument("--compiler_workdir", type=str,
-                        default="/opt/dlami/nvme/compiler_workdir",
-                        help="Compiler working directory")
-    parser.add_argument("--model_path", type=str, default=None,
-                        help="Path to model (local dir or HuggingFace ID)")
+    parser.add_argument(
+        "--image_size",
+        type=int,
+        default=448,
+        help="Vision encoder input image size (default: 448)",
+    )
+    parser.add_argument(
+        "--compiled_models_dir",
+        type=str,
+        default="/opt/dlami/nvme/compiled_models",
+        help="Output directory for compiled models",
+    )
+    parser.add_argument(
+        "--compiler_workdir",
+        type=str,
+        default="/opt/dlami/nvme/compiler_workdir",
+        help="Compiler working directory",
+    )
+    parser.add_argument(
+        "--model_path",
+        type=str,
+        default=None,
+        help="Path to model (local dir or HuggingFace ID)",
+    )
+    parser.add_argument(
+        "--load_bf16",
+        action="store_true",
+        default=False,
+        help="Load pipeline in bf16 to save memory (for trn2.3xlarge). "
+        "Weights are automatically cast to fp32 for compilation.",
+    )
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Fixes and improvements for running Qwen-Image-Edit on **trn2.3xlarge** (LNC=2, TP=4, CP=1):
- Fix VAE decoder compilation failure at LNC=2 (NEURON_CUSTOM_SILU/NEURON_FUSE_SOFTMAX cause NCC_IBIR182)
- Fix vision encoder OOM on instances with <96GB RAM (add --load_bf16 flag with explicit fp32 checkpoint cast)
- Document trn2.3xlarge configuration, known issues, and GPU benchmark comparison
- Document Qwen-Image-Edit-2511 compatibility (architecturally identical to 2509)
## Changes
### 1. compile_vae.py — VAE Decoder LNC=2 Fix
At LNC=2 (trn2.3xlarge default), NEURON_CUSTOM_SILU=1 and NEURON_FUSE_SOFTMAX=1 cause an internal compiler error (NCC_IBIR182) for the VAE decoder. The encoder compiles fine.
**Fix**: Automatically disable both flags before decoder compilation and restore afterward.
### 2. compile_vision_encoder_v3.py — bf16 Loading + fp32 Checkpoint Cast
Loading the full pipeline in fp32 (~95 GB) OOMs on trn2.3xlarge (64 GB RAM). Added --load_bf16 flag that loads in bf16 and explicitly casts checkpoints to fp32.
### 3. README.md — trn2.3xlarge Documentation and GPU Benchmark
- Configuration: LNC=2, TP=4, CP=1 (world_size=4), all components on Neuron
- GPU benchmark (g6e.12xlarge, 4x L40S): Neuron is 4.4x cheaper per image and 1.72x faster for multi-image
- Qwen-Image-Edit-2511 compatibility confirmed
## Benchmark (trn2.3xlarge vs L40S GPU)
| Test | trn2.3xlarge | GPU (L40S) | Ratio |
|------|-------------|---------------|-------|
| 1 img, 1024x1024, 28 steps | 83.1s (2.97 s/step) | 67.6s (2.41 s/step) | Neuron 1.23x slower |
| 3 img, 768x1280, 28 steps | 92.9s (3.32 s/step) | 160.1s (5.72 s/step) | **Neuron 1.72x faster** |
| Cost per image (spot) | **\$0.021** | \$0.093 | **4.4x cheaper** |